### PR TITLE
v3: Redesign API

### DIFF
--- a/v3/assert.go
+++ b/v3/assert.go
@@ -25,15 +25,32 @@ package assert
 import "fmt"
 
 // UsingPanic creates an Asserter that panics to report failures.
+//
+// If you're using this library in tests you probably want UsingFmt instead.
 func UsingPanic() Asserter {
 	return Using(nil)
 }
 
 // Using creates an Asserter that uses onErr to report failures.
+//
+// Using is the most generic of the Using* functions.
+//
+// If you're using this library in tests you probably want UsingFmt instead.
 func Using(onErr func(error)) Asserter {
 	return Asserter{onErr}
 }
 
+// UsingFmt creates an Asserter that uses fmtFunc to report failures.
+//
+// If you're using this library in tests you probably want to call either
+//
+//	assert.UsingFmt(t.Errorf).That(somethingHolds())
+//
+// or
+//
+//	assert.UsingFmt(t.Fatalf).That(somethingHolds())
+//
+// depending on whether you want the test to continue on failure or not.
 func UsingFmt(fmtFunc func(string, ...any)) Asserter {
 	onErr := func(err error) { fmtFunc(err.Error()) }
 	return Asserter{onErr}

--- a/v3/assert.go
+++ b/v3/assert.go
@@ -1,0 +1,80 @@
+// MIT License
+//
+// Copyright (c) 2022 Karol Marcjan
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package assert
+
+import "fmt"
+
+// UsingPanic creates an Asserter that panics to report failures.
+func UsingPanic() Asserter {
+	return Using(nil)
+}
+
+// Using creates an Asserter that uses onErr to report failures.
+func Using(onErr func(error)) Asserter {
+	return Asserter{onErr}
+}
+
+func UsingFmt(fmtFunc func(string, ...any)) Asserter {
+	onErr := func(err error) { fmtFunc(err.Error()) }
+	return Asserter{onErr}
+}
+
+// An Asserter is used to make assertions.
+type Asserter struct{ onErr func(error) }
+
+// That asserts there is no problem (ie, the error is nil).
+//
+// The error func of the asserter receives any non-nil error passed in.
+// If the asserter has a nil error func, That panics with the message of the error.
+//
+// When the assertion passes, the same asserter is returned.
+// This enables chaining multiple assertions that share an error func.
+func (a Asserter) That(err error) Asserter {
+	if err != nil {
+		a.fail(err)
+	}
+	return a
+}
+
+// True asserts cond is true.
+//
+// The error func of the asserter receives msgFmt and args as input.
+// If the asserter has a nil error func, True panics with a message formatted by fmt.Sprintf.
+//
+// When the assertion passes, the same asserter is returned.
+// This enables chaining multiple assertions that share and error func.
+func (a Asserter) True(cond bool, msgFmt string, args ...any) Asserter {
+	if !cond {
+		err := fmt.Errorf(msgFmt, args...)
+		a.fail(err)
+	}
+	return a
+}
+
+func (a Asserter) fail(err error) {
+	if a.onErr == nil {
+		panic(err.Error())
+	}
+
+	a.onErr(err)
+}

--- a/v3/assert_test.go
+++ b/v3/assert_test.go
@@ -1,0 +1,102 @@
+// MIT License
+//
+// Copyright (c) 2018 Karol Marcjan
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package assert_test
+
+import (
+	"testing"
+
+	"github.com/szabba/assert/v3"
+)
+
+func TestPassingAssertionWithNilErrorFuncDoesNotPanic(t *testing.T) {
+	// given
+	// when
+	p := catchPanic(func() { assert.UsingPanic().True(true, "OK") })
+
+	// then
+	if p != nil {
+		t.Errorf("unexpected panic: %#v", p)
+	}
+}
+
+func TestFailingAssertionWithNilErrorFuncPanicsWithTheFormattedMessage(t *testing.T) {
+	// given
+	// when
+	p := catchPanic(func() { assert.UsingPanic().True(false, "Oops: %#v", false) })
+
+	// then
+	wantMsg := "Oops: false"
+	if p != wantMsg {
+		t.Errorf("got panic %#v, not %q", p, wantMsg)
+	}
+}
+
+func TestPassingAssertionDoesNotCallNonNilErrorFunc(t *testing.T) {
+	// given
+	called := false
+	errFunc := func(_ error) { called = true }
+
+	// when
+	assert.Using(errFunc).True(true, "OK")
+
+	// then
+	if called {
+		t.Error("the ErrorFunc was called")
+	}
+}
+
+func TestFailingAssertionCallsNonNilErrorFunc(t *testing.T) {
+	// given
+	var got struct {
+		called bool
+		err    error
+	}
+	errFunc := func(err error) {
+		got.called = true
+		got.err = err
+	}
+
+	// when
+	assert.Using(errFunc).True(false, "Oops: %#v", false)
+
+	// then
+	if !got.called {
+		t.Errorf("Error handler was not called")
+	}
+
+	if got.err == nil {
+		t.Errorf("Error passed to handler is nil")
+		return
+	}
+
+	wantMsg := "Oops: false"
+	if got.err.Error() != wantMsg {
+		t.Errorf("Error passd to handler has message %v, not %v", got.err.Error(), wantMsg)
+	}
+}
+
+func catchPanic(f func()) (caught any) {
+	defer func() { caught = recover() }()
+	f()
+	return caught
+}

--- a/v3/assertions/assertiontesting/errfunc.go
+++ b/v3/assertions/assertiontesting/errfunc.go
@@ -1,0 +1,101 @@
+// MIT License
+//
+// Copyright (c) 2022 Karol Marcjan
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package assertiontesting
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	errErrFuncNotCalled = errors.New("error function was not called")
+	errErrFuncCalled    = errors.New("error function was called")
+)
+
+// ErrFunc is an object that records the details of a single call to an error function.
+type ErrFunc struct {
+	called bool
+
+	err error
+}
+
+// Record is a method that can be used as an error function.
+//
+// Pass f.Record to assert.Using in order to test an assertion helper.
+//
+// If Record gets called, the details of the call are recorded.
+// If Record is called more than once, it panics.
+//
+// The other methods on the object can be used to make assertions about the call.
+// This works both when Record was actually called and not.
+func (f *ErrFunc) Record(err error) {
+
+	if f.called {
+		panic("error function called multiple times")
+	}
+
+	if err == nil {
+		panic("error function called with a nil error")
+	}
+
+	f.called = true
+	f.err = err
+}
+
+// Called is a helper to assert that the error function was called.
+//
+// See Record for more details.
+func (f *ErrFunc) Called() error {
+
+	if !f.called {
+		return errErrFuncNotCalled
+	}
+	return nil
+}
+
+// NotCalled is a helper to assert that the error func was not called.
+//
+// See Record for more details.
+func (f *ErrFunc) NotCalled() error {
+
+	if f.called {
+		return errErrFuncCalled
+	}
+	return nil
+}
+
+// MessageFormatsTo is a helper to assert the formatting of the message the error function was called with.
+//
+// See Record for more details.
+func (f *ErrFunc) MessageFormatsTo(want string) error {
+
+	if !f.called {
+		return errErrFuncCalled
+	}
+
+	got := f.err.Error()
+	if got != want {
+		return fmt.Errorf("got assertion error with message %q, not %q", got, want)
+	}
+	return nil
+}

--- a/v3/assertions/theerr/theerr.go
+++ b/v3/assertions/theerr/theerr.go
@@ -1,0 +1,86 @@
+// MIT License
+//
+// Copyright (c) 2022 Karol Marcjan
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Package theerr provides reusable assertions about a single error.
+package theerr
+
+import (
+	"errors"
+	"fmt"
+)
+
+// IsNil asserts that the error is nil.
+func IsNil(err error) error {
+	if err != nil {
+		return fmt.Errorf("unexpected error: %w", err)
+	}
+	return nil
+}
+
+// IsNotNil asserts that the error is not nil.
+//
+// This is less precise than [Is] or [IsA].
+// It is better than nothing when there aren't exposed sentinels / types to check for.
+func IsNotNil(err error) error {
+	if err == nil {
+		return errUnexpectedNil
+	}
+	return nil
+}
+
+var errUnexpectedNil = errors.New("unexpected nil error")
+
+// Is asserts that got is the wanted error.
+//
+// This is aware of error composition.
+// For more details see [errors.Is].
+func Is(got, want error) error {
+
+	if want == nil {
+		return IsNil(got)
+	}
+
+	if !errors.Is(got, want) {
+		return fmt.Errorf("got error %q, not %q", got, want)
+	}
+
+	return nil
+}
+
+// IsA asserts that the error can be viewed as an error of type T.
+//
+// This is aware of error composition.
+// For more details see [errors.As].
+func IsA[T error](err error) error {
+
+	var typedErr T
+
+	if err == nil {
+		return fmt.Errorf("got nil error, not a %T", typedErr)
+	}
+
+	if !errors.As(err, &typedErr) {
+		return fmt.Errorf("got error of type %T, not %T", err, typedErr)
+	}
+
+	return nil
+}

--- a/v3/assertions/theerr/theerr_test.go
+++ b/v3/assertions/theerr/theerr_test.go
@@ -1,0 +1,193 @@
+// MIT License
+//
+// Copyright (c) 2022 Karol Marcjan
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package theerr_test
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/szabba/assert/v3"
+	"github.com/szabba/assert/v3/assertions/assertiontesting"
+	theerr "github.com/szabba/assert/v3/assertions/theerr"
+)
+
+func TestIsNil(t *testing.T) {
+
+	t.Run("True", func(t *testing.T) {
+		// given
+		var errFunc assertiontesting.ErrFunc
+
+		// when
+		assert.Using(errFunc.Record).That(theerr.IsNil(nil))
+
+		// then
+		assert.UsingFmt(t.Errorf).That(errFunc.NotCalled())
+	})
+
+	t.Run("False", func(t *testing.T) {
+		// given
+		var errFunc assertiontesting.ErrFunc
+
+		// when
+		assert.Using(errFunc.Record).That(theerr.IsNil(io.EOF))
+
+		// then
+		assert.
+			UsingFmt(t.Errorf).
+			That(errFunc.Called()).
+			That(errFunc.MessageFormatsTo("unexpected error: EOF"))
+	})
+
+}
+
+func TestIsNotNil(t *testing.T) {
+
+	t.Run("True", func(t *testing.T) {
+		// given
+		var errFunc assertiontesting.ErrFunc
+
+		// when
+		assert.Using(errFunc.Record).That(theerr.IsNotNil(io.EOF))
+
+		// then
+		assert.UsingFmt(t.Errorf).That(errFunc.NotCalled())
+	})
+
+	t.Run("False", func(t *testing.T) {
+		// given
+		var errFunc assertiontesting.ErrFunc
+
+		// when
+		assert.Using(errFunc.Record).That(theerr.IsNotNil(nil))
+
+		// then
+		assert.
+			UsingFmt(t.Errorf).
+			That(errFunc.Called()).
+			That(errFunc.MessageFormatsTo("unexpected nil error"))
+	})
+
+}
+
+func TestIs(t *testing.T) {
+
+	t.Run("True/Nil", func(t *testing.T) {
+		// given
+		var errFunc assertiontesting.ErrFunc
+
+		// when
+		assert.Using(errFunc.Record).That(theerr.Is(nil, nil))
+
+		// then
+		assert.UsingFmt(t.Errorf).That(errFunc.NotCalled())
+	})
+
+	t.Run("True/Exact", func(t *testing.T) {
+		// given
+		var errFunc assertiontesting.ErrFunc
+
+		// when
+		assert.Using(errFunc.Record).That(theerr.Is(io.EOF, io.EOF))
+
+		// then
+		assert.UsingFmt(t.Errorf).That(errFunc.NotCalled())
+	})
+
+	t.Run("True/Wrapped", func(t *testing.T) {
+		// given
+		var errFunc assertiontesting.ErrFunc
+
+		wrappedErr := fmt.Errorf("failed: %w", io.EOF)
+
+		// when
+		assert.Using(errFunc.Record).That(theerr.Is(wrappedErr, io.EOF))
+
+		// then
+		assert.UsingFmt(t.Errorf).That(errFunc.NotCalled())
+	})
+
+	t.Run("False", func(t *testing.T) {
+		// given
+		var errFunc assertiontesting.ErrFunc
+
+		newErr := errors.New("oops")
+
+		// when
+		assert.Using(errFunc.Record).That(theerr.Is(newErr, io.EOF))
+
+		// then
+		assert.UsingFmt(t.Errorf).
+			That(errFunc.Called()).
+			That(errFunc.MessageFormatsTo(`got error "oops", not "EOF"`))
+	})
+
+}
+
+func TestIsA(t *testing.T) {
+
+	t.Run("True", func(t *testing.T) {
+		// given
+		var errFunc assertiontesting.ErrFunc
+		err := new(os.PathError)
+
+		// when
+		assert.Using(errFunc.Record).
+			That(theerr.IsA[*os.PathError](err))
+
+		// then
+		assert.UsingFmt(t.Errorf).That(errFunc.NotCalled())
+	})
+
+	t.Run("False/Nil", func(t *testing.T) {
+		// given
+		var errFunc assertiontesting.ErrFunc
+
+		// when
+		assert.Using(errFunc.Record).
+			That(theerr.IsA[*os.PathError](nil))
+
+		// then
+		assert.UsingFmt(t.Errorf).
+			That(errFunc.Called()).
+			That(errFunc.MessageFormatsTo("got nil error, not a *fs.PathError"))
+	})
+
+	t.Run("False/TypeMismatch", func(t *testing.T) {
+		// given
+		var errFunc assertiontesting.ErrFunc
+		err := new(os.SyscallError)
+
+		// when
+		assert.Using(errFunc.Record).
+			That(theerr.IsA[*os.PathError](err))
+
+		// then
+		assert.UsingFmt(t.Errorf).
+			That(errFunc.Called()).
+			That(errFunc.MessageFormatsTo("got error of type *os.SyscallError, not *fs.PathError"))
+	})
+
+}

--- a/v3/assertions/theslice/theslice.go
+++ b/v3/assertions/theslice/theslice.go
@@ -1,0 +1,157 @@
+// MIT License
+//
+// Copyright (c) 2022 Karol Marcjan
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Package theslice provides reusable assertions about slices.
+package theslice
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Empty asserts that s is an empty slice.
+func Empty[S ~[]T, T any](s S) error {
+	if len(s) != 0 {
+		return fmt.Errorf("got non-empty slice %#v", s)
+	}
+	return nil
+}
+
+// NotEmpty asserts that s is not an empty slice.
+func NotEmpty[S ~[]T, T any](s S) error {
+	if len(s) == 0 {
+		return fmt.Errorf("got empty slice %#v", s)
+	}
+	return nil
+}
+
+// Equal asserts that an actual slice is equal to an expected one.
+//
+// Nil slices are never equal to non-nil slices.
+// Only slices of equal length can be equal.
+// The elements at each index must be equal in both slices.
+func Equal[S ~[]T, T comparable](got, want S) error {
+	if got == nil && want != nil {
+		return fmt.Errorf("got nil, not %#v", want)
+	}
+
+	if got != nil && want == nil {
+		return fmt.Errorf("got %#v, not nil", got)
+	}
+
+	if len(got) != len(want) {
+		return fmt.Errorf(
+			"got %#v (of length %d), not %#v (of length %d)",
+			got, len(got), want, len(want))
+	}
+
+	diffs := make([]int, 0, len(got))
+	for i := range got {
+		if got[i] != want[i] {
+			diffs = append(diffs, i)
+		}
+	}
+
+	errs := make([]error, 0, len(diffs))
+	for _, d := range diffs {
+		errs = append(errs, fmt.Errorf(
+			"element at position %d is %#v, not %#v",
+			d, got[d], want[d]))
+	}
+
+	if len(diffs) > 0 {
+		sep := " "
+		if len(errs) > 1 {
+			sep = "\n"
+		}
+		return fmt.Errorf(
+			"got slice %#v, not %#v:%s%w",
+			got, want, sep, errors.Join(errs...))
+	}
+
+	return nil
+}
+
+// NotEqual asserts that the actual slice is not equal to another.
+//
+// For more details look at Equal.
+func NotEqual[S ~[]T, T comparable](got, wantNot S) error {
+	if got == nil && wantNot != nil {
+		return nil
+	}
+
+	if got != nil && wantNot == nil {
+		return nil
+	}
+
+	if len(got) != len(wantNot) {
+		return nil
+	}
+
+	for i := range got {
+		if got[i] != wantNot[i] {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("got unwanted value %#v", got)
+}
+
+// Length asserts the len(s) is n.
+func Length[S ~[]T, T any](s S, n int) error {
+	if len(s) != n {
+		return fmt.Errorf("got slice of length %d, not %d", len(s), n)
+	}
+	return nil
+}
+
+// LengthNot asserts that len(s) is not n.
+func LengthNot[S ~[]T, T any](s S, n int) error {
+	if len(s) == n {
+		return fmt.Errorf("got slice of length %d", len(s))
+	}
+	return nil
+}
+
+// LengthAtLeast asserts that len(s) >= n.
+func LengthAtLeast[S ~[]T, T any](s S, n int) error {
+	if len(s) < n {
+		return fmt.Errorf("got slice of length %d, less than %d", len(s), n)
+	}
+	return nil
+}
+
+// At assers that the i-th element of s passes the assertion in f.
+func At[S ~[]T, T any](s S, i int, f func(t T) error) error {
+	err := LengthAtLeast(s, i+1)
+	if err != nil {
+		return err
+	}
+
+	el := s[i]
+	err = f(el)
+	if err != nil {
+		return fmt.Errorf("element %d, %#v does not pass: %w", i, el, err)
+	}
+
+	return nil
+}

--- a/v3/assertions/theslice/theslice.go
+++ b/v3/assertions/theslice/theslice.go
@@ -50,6 +50,17 @@ func NotEmpty[S ~[]T, T any](s S) error {
 // Only slices of equal length can be equal.
 // The elements at each index must be equal in both slices.
 func Equal[S ~[]T, T comparable](got, want S) error {
+	return EqualFunc(got, want, func(l, r T) bool { return l == r })
+}
+
+// EqualFunc asserts that an actual slice is equal to an expected one.
+// Elements are compared for equality using the function eq.
+//
+// Nil slices are never equal to non-nil slices.
+// Only slices of equal length can be equal.
+// The elements at each index must be equal in both slices, as determined by eq.
+func EqualFunc[S ~[]T, T any](got, want S, eq func(T, T) bool) error {
+
 	if got == nil && want != nil {
 		return fmt.Errorf("got nil, not %#v", want)
 	}
@@ -66,7 +77,7 @@ func Equal[S ~[]T, T comparable](got, want S) error {
 
 	diffs := make([]int, 0, len(got))
 	for i := range got {
-		if got[i] != want[i] {
+		if !eq(got[i], want[i]) {
 			diffs = append(diffs, i)
 		}
 	}

--- a/v3/assertions/theslice/theslice_test.go
+++ b/v3/assertions/theslice/theslice_test.go
@@ -1,0 +1,585 @@
+// MIT License
+//
+// Copyright (c) 2022 Karol Marcjan
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package theslice_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/szabba/assert/v3"
+	"github.com/szabba/assert/v3/assertions/assertiontesting"
+	"github.com/szabba/assert/v3/assertions/theval"
+
+	"github.com/szabba/assert/v3/assertions/theslice"
+)
+
+func TestEmpty(t *testing.T) {
+
+	t.Run("True/Nil", func(t *testing.T) {
+		// given
+		var errFunc assertiontesting.ErrFunc
+
+		// when
+		assert.Using(errFunc.Record).That(theslice.Empty[[]int](nil))
+
+		// then
+		assert.UsingFmt(t.Errorf).That(errFunc.NotCalled())
+	})
+
+	t.Run("True/NotNil", func(t *testing.T) {
+		// given
+		var errFunc assertiontesting.ErrFunc
+		s := []int{}
+
+		// when
+		assert.Using(errFunc.Record).That(theslice.Empty(s))
+
+		// then
+		assert.UsingFmt(t.Errorf).That(errFunc.NotCalled())
+	})
+
+	t.Run("False", func(t *testing.T) {
+		// given
+		var errFunc assertiontesting.ErrFunc
+		s := []int{1, 2}
+
+		// when
+		assert.Using(errFunc.Record).That(theslice.Empty(s))
+
+		// then
+		assert.UsingFmt(t.Errorf).
+			That(errFunc.Called()).
+			That(errFunc.MessageFormatsTo("got non-empty slice []int{1, 2}"))
+	})
+
+}
+
+func TestNotEmpty(t *testing.T) {
+
+	t.Run("True", func(t *testing.T) {
+		// given
+		var errFunc assertiontesting.ErrFunc
+		s := []int{1, 2}
+
+		// when
+		assert.Using(errFunc.Record).
+			That(theslice.NotEmpty(s))
+
+		// then
+		assert.UsingFmt(t.Errorf).That(errFunc.NotCalled())
+	})
+
+	t.Run("False/NotNil", func(t *testing.T) {
+		// given
+		var errFunc assertiontesting.ErrFunc
+		s := []int{}
+
+		// when
+		assert.Using(errFunc.Record).That(theslice.NotEmpty(s))
+
+		// then
+		assert.UsingFmt(t.Errorf).
+			That(errFunc.Called()).
+			That(errFunc.MessageFormatsTo("got empty slice []int{}"))
+	})
+
+	t.Run("False/Nil", func(t *testing.T) {
+		// given
+		var errFunc assertiontesting.ErrFunc
+
+		// when
+		assert.Using(errFunc.Record).That(theslice.NotEmpty[[]int](nil))
+
+		// then
+		assert.UsingFmt(t.Errorf).
+			That(errFunc.Called()).
+			That(errFunc.MessageFormatsTo("got empty slice []int(nil)"))
+	})
+
+}
+
+func TestEqual(t *testing.T) {
+
+	nameGiven := func(got, want []int) string {
+		mightHaveSpaces := fmt.Sprintf("Got%#vWant%#v", got, want)
+		return strings.ReplaceAll(mightHaveSpaces, " ", "")
+	}
+
+	okCases := [][]int{
+		nil,
+		{},
+		{0},
+		{0, 1},
+	}
+
+	for _, tt := range okCases {
+		name := nameGiven(tt, tt)
+
+		t.Run(name, func(t *testing.T) {
+			// given
+			var onErr assertiontesting.ErrFunc
+
+			// when
+			assert.Using(onErr.Record).That(theslice.Equal(tt, tt))
+
+			// then
+			assert.UsingFmt(t.Errorf).That(onErr.NotCalled())
+		})
+	}
+
+	oopsCases := []struct {
+		Got, Want []int
+		Message   string
+	}{
+		{
+			Got:     nil,
+			Want:    []int{},
+			Message: "got nil, not []int{}",
+		},
+		{
+			Got:     []int{},
+			Want:    nil,
+			Message: "got []int{}, not nil",
+		},
+		{
+			Got:     []int{},
+			Want:    []int{0},
+			Message: "got []int{} (of length 0), not []int{0} (of length 1)",
+		},
+		{
+			Got:     []int{1},
+			Want:    []int{2},
+			Message: "got slice []int{1}, not []int{2}: element at position 0 is 1, not 2",
+		},
+		{
+			Got:     []int{1, 2},
+			Want:    []int{1, 3},
+			Message: "got slice []int{1, 2}, not []int{1, 3}: element at position 1 is 2, not 3",
+		},
+		{
+			Got:  []int{1, 2},
+			Want: []int{3, 4},
+			Message: lines(
+				"got slice []int{1, 2}, not []int{3, 4}:",
+				"element at position 0 is 1, not 3",
+				"element at position 1 is 2, not 4",
+			),
+		},
+	}
+
+	for _, tt := range oopsCases {
+
+		name := nameGiven(tt.Got, tt.Want)
+
+		t.Run(name, func(t *testing.T) {
+			// given
+			var onErr assertiontesting.ErrFunc
+
+			// when
+			assert.
+				Using(onErr.Record).
+				That(theslice.Equal(tt.Got, tt.Want))
+
+			// then
+			assert.
+				UsingFmt(t.Errorf).
+				That(onErr.Called()).
+				That(onErr.MessageFormatsTo(tt.Message))
+		})
+	}
+}
+
+func TestNotEqual(t *testing.T) {
+
+	nameGiven := func(got, want []int) string {
+		mightHaveSpaces := fmt.Sprintf("Got%#vWant%#v", got, want)
+		return strings.ReplaceAll(mightHaveSpaces, " ", "")
+	}
+
+	oopsCases := []struct {
+		Slice   []int
+		Message string
+	}{
+		{
+			Slice:   nil,
+			Message: "got unwanted value []int(nil)",
+		},
+		{
+			Slice:   []int{},
+			Message: "got unwanted value []int{}",
+		},
+		{
+			Slice:   []int{0},
+			Message: "got unwanted value []int{0}",
+		},
+		{
+			Slice:   []int{1, 2},
+			Message: "got unwanted value []int{1, 2}",
+		},
+	}
+
+	for _, tt := range oopsCases {
+		name := nameGiven(tt.Slice, tt.Slice)
+
+		t.Run(name, func(t *testing.T) {
+			// given
+			var errFunc assertiontesting.ErrFunc
+
+			// when
+			assert.Using(errFunc.Record).
+				That(theslice.NotEqual(tt.Slice, tt.Slice))
+
+			// then
+			assert.UsingFmt(t.Errorf).
+				That(errFunc.Called()).
+				That(errFunc.MessageFormatsTo(tt.Message))
+		})
+	}
+
+	okCases := []struct {
+		Got, Want []int
+	}{
+		{Got: nil, Want: []int{}},
+		{Got: []int{}, Want: nil},
+		{Got: []int{1}, Want: []int{2, 3}},
+		{Got: []int{2, 3}, Want: []int{1}},
+		{Got: []int{0}, Want: []int{1}},
+		{Got: []int{1}, Want: []int{0}},
+	}
+
+	for _, tt := range okCases {
+		name := nameGiven(tt.Got, tt.Want)
+
+		t.Run(name, func(t *testing.T) {
+			// given
+			var errFunc assertiontesting.ErrFunc
+
+			// when
+			assert.Using(errFunc.Record).
+				That(theslice.NotEqual(tt.Got, tt.Want))
+
+			// then
+			assert.UsingFmt(t.Errorf).
+				That(errFunc.NotCalled())
+		})
+	}
+
+}
+
+func TestLength(t *testing.T) {
+
+	okCases := map[string]struct {
+		Slice  []int
+		Length int
+	}{
+		"True/Nil":   {Slice: nil, Length: 0},
+		"True/Empty": {Slice: []int{}, Length: 0},
+		"True/1":     {Slice: []int{1}, Length: 1},
+		"True/2":     {Slice: []int{1, 2}, Length: 2},
+		"True/3":     {Slice: []int{1, 2, 3}, Length: 3},
+	}
+
+	for name, tt := range okCases {
+		t.Run(name, func(t *testing.T) {
+			// given
+			var errFunc assertiontesting.ErrFunc
+
+			// when
+			assert.Using(errFunc.Record).
+				That(theslice.Length(tt.Slice, tt.Length))
+
+			// then
+			assert.UsingFmt(t.Errorf).That(errFunc.NotCalled())
+		})
+	}
+
+	oopsCases := map[string]struct {
+		Slice   []int
+		Length  int
+		Message string
+	}{
+		"False/NilHasLenght1": {
+			Slice:   nil,
+			Length:  1,
+			Message: "got slice of length 0, not 1",
+		},
+		"False/EmptyHasLength1": {
+			Slice:   []int{},
+			Length:  1,
+			Message: "got slice of length 0, not 1",
+		},
+		"False/Make1HasLength2": {
+			Slice:   make([]int, 1),
+			Length:  2,
+			Message: "got slice of length 1, not 2",
+		},
+		"False/Make2HasLength3": {
+			Slice:   make([]int, 2),
+			Length:  3,
+			Message: "got slice of length 2, not 3",
+		},
+	}
+
+	for name, tt := range oopsCases {
+		t.Run(name, func(t *testing.T) {
+			// given
+			var errFunc assertiontesting.ErrFunc
+
+			// when
+			assert.Using(errFunc.Record).
+				That(theslice.Length(tt.Slice, tt.Length))
+
+			// then
+			assert.UsingFmt(t.Errorf).
+				That(errFunc.Called()).
+				That(errFunc.MessageFormatsTo(tt.Message))
+		})
+	}
+
+}
+
+func TestLengthNot(t *testing.T) {
+
+	okCases := map[string]struct {
+		Slice  []int
+		Length int
+	}{
+		"True/NilNotLength1": {
+			Slice:  nil,
+			Length: 1,
+		},
+		"True/EmptyNotLength1": {
+			Slice:  []int{},
+			Length: 1,
+		},
+		"True/Make1NotLength2": {
+			Slice:  make([]int, 1),
+			Length: 2,
+		},
+		"True/Make2NotLength3": {
+			Slice:  make([]int, 2),
+			Length: 3,
+		},
+	}
+
+	for name, tt := range okCases {
+		t.Run(name, func(t *testing.T) {
+			// given
+			var errFunc assertiontesting.ErrFunc
+
+			// when
+			assert.Using(errFunc.Record).
+				That(theslice.LengthNot(tt.Slice, tt.Length))
+
+			// then
+			assert.UsingFmt(t.Errorf).That(errFunc.NotCalled())
+		})
+	}
+
+	oopsCases := map[string]struct {
+		Slice   []int
+		Length  int
+		Message string
+	}{
+		"False/NilNotLength0": {
+			Slice:   nil,
+			Length:  0,
+			Message: "got slice of length 0",
+		},
+		"False/EmptyNotLength0": {
+			Slice:   []int{},
+			Length:  0,
+			Message: "got slice of length 0",
+		},
+		"False/Make1NotLength1": {
+			Slice:   make([]int, 1),
+			Length:  1,
+			Message: "got slice of length 1",
+		},
+		"False/Make2NotLength2": {
+			Slice:   make([]int, 2),
+			Length:  2,
+			Message: "got slice of length 2",
+		},
+	}
+
+	for name, tt := range oopsCases {
+		t.Run(name, func(t *testing.T) {
+			// given
+			var errFunc assertiontesting.ErrFunc
+
+			// when
+			assert.Using(errFunc.Record).
+				That(theslice.LengthNot(tt.Slice, tt.Length))
+
+			// then
+			assert.UsingFmt(t.Errorf).
+				That(errFunc.Called()).
+				That(errFunc.MessageFormatsTo(tt.Message))
+		})
+	}
+
+}
+
+func TestLengthAtLeast(t *testing.T) {
+
+	okCases := map[string]struct {
+		Slice  []int
+		Length int
+	}{
+		"True/NilLengthAtLeast0": {
+			Slice:  nil,
+			Length: 0,
+		},
+		"True/EmptyLengthAtLeast0": {
+			Slice:  []int{},
+			Length: 0,
+		},
+		"True/Make1LengthAtLeast0": {
+			Slice:  make([]int, 1),
+			Length: 0,
+		},
+		"True/Make1LengthAtLeast1": {
+			Slice:  make([]int, 1),
+			Length: 1,
+		},
+		"True/Make2LengthAtLeast2": {
+			Slice:  make([]int, 3),
+			Length: 2,
+		},
+	}
+
+	for name, tt := range okCases {
+		t.Run(name, func(t *testing.T) {
+			// given
+			var errFunc assertiontesting.ErrFunc
+
+			// when
+			assert.Using(errFunc.Record).
+				That(theslice.LengthAtLeast(tt.Slice, tt.Length))
+
+			// then
+			assert.UsingFmt(t.Errorf).That(errFunc.NotCalled())
+		})
+	}
+
+	oopsCases := map[string]struct {
+		Slice   []int
+		Length  int
+		Message string
+	}{
+		"False/NilNotLengthAtLeast1": {
+			Slice:   nil,
+			Length:  1,
+			Message: "got slice of length 0, less than 1",
+		},
+		"False/EmptyNotLengthAtLeast1": {
+			Slice:   []int{},
+			Length:  1,
+			Message: "got slice of length 0, less than 1",
+		},
+
+		"False/EmptyNotLengthAtLeast11": {
+			Slice:   []int{},
+			Length:  11,
+			Message: "got slice of length 0, less than 11",
+		},
+		"False/Make1NotLengthAtLeast3": {
+			Slice:   make([]int, 1),
+			Length:  3,
+			Message: "got slice of length 1, less than 3",
+		},
+	}
+
+	for name, tt := range oopsCases {
+		t.Run(name, func(t *testing.T) {
+			// given
+			var errFunc assertiontesting.ErrFunc
+
+			// when
+			assert.Using(errFunc.Record).
+				That(theslice.LengthAtLeast(tt.Slice, tt.Length))
+
+			// then
+			assert.UsingFmt(t.Errorf).
+				That(errFunc.Called()).
+				That(errFunc.MessageFormatsTo(tt.Message))
+		})
+	}
+
+}
+
+func TestAt(t *testing.T) {
+
+	t.Run("True", func(t *testing.T) {
+		// given
+		var errFunc assertiontesting.ErrFunc
+
+		// when
+		assert.Using(errFunc.Record).
+			That(theslice.At([]int{3, 7, 4}, 1, theval.NotZero[int]))
+
+		// then
+		assert.UsingFmt(t.Errorf).That(errFunc.NotCalled())
+	})
+
+	oopsCases := map[string]struct {
+		Slice   []int
+		At      int
+		Assert  func(int) error
+		Message string
+	}{
+		"False/SliceTooShort": {
+			Slice:   nil,
+			At:      1,
+			Assert:  theval.NotZero[int],
+			Message: "got slice of length 0, less than 2",
+		},
+		"False/ElementDoesNotPass": {
+			Slice:   []int{3, 7, 4},
+			At:      1,
+			Assert:  theval.Zero[int],
+			Message: "element 1, 7 does not pass: got 7, not zero value 0",
+		},
+	}
+
+	for name, tt := range oopsCases {
+		t.Run(name, func(t *testing.T) {
+			// given
+			var errFunc assertiontesting.ErrFunc
+
+			// when
+			assert.Using(errFunc.Record).
+				That(theslice.At(tt.Slice, tt.At, tt.Assert))
+
+			// then
+			assert.UsingFmt(t.Errorf).
+				That(errFunc.Called()).
+				That(errFunc.MessageFormatsTo(tt.Message))
+		})
+	}
+
+}
+
+func lines(ls ...string) string { return strings.Join(ls, "\n") }

--- a/v3/assertions/theval/theval.go
+++ b/v3/assertions/theval/theval.go
@@ -1,0 +1,75 @@
+// MIT License
+//
+// Copyright (c) 2022 Karol Marcjan
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Package theval provides the most basic reusable assertions.
+package theval
+
+import (
+	"fmt"
+	"reflect"
+
+	"golang.org/x/exp/constraints"
+)
+
+// Equal asserts that an actual value is equal to an expected value of the same.
+func Equal[T comparable](got, want T) error {
+	if got != want {
+		return fmt.Errorf("got %#v, not %#v", got, want)
+	}
+	return nil
+}
+
+// NotEqual asserts that an actual value is not equal to another.
+func NotEqual[T comparable](got, wantNot T) error {
+	if got == wantNot {
+		return fmt.Errorf("got unwanted value %#v", got)
+	}
+	return nil
+}
+
+// LessThan asserts that an actual value is less than another.
+func LessThan[T constraints.Ordered](got, want T) error {
+	if got >= want {
+		return fmt.Errorf("got %v >= %v", got, want)
+	}
+	return nil
+}
+
+// Zero asserts that v is the zero value of it's underlying type.
+func Zero[T any](v T) error {
+	rv := reflect.ValueOf(v)
+
+	if !rv.IsZero() {
+		var z T
+		return fmt.Errorf("got %#v, not zero value %#v", v, z)
+	}
+
+	return nil
+}
+
+// NotZero asserts that v is not the zero value of it's underlying type.
+func NotZero[T any](v T) error {
+	if reflect.ValueOf(v).IsZero() {
+		return fmt.Errorf("got zero value %#v", v)
+	}
+	return nil
+}

--- a/v3/assertions/theval/theval_test.go
+++ b/v3/assertions/theval/theval_test.go
@@ -1,0 +1,195 @@
+// MIT License
+//
+// Copyright (c) 2022 Karol Marcjan
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package theval_test
+
+import (
+	"testing"
+
+	"github.com/szabba/assert/v3"
+	"github.com/szabba/assert/v3/assertions/assertiontesting"
+
+	"github.com/szabba/assert/v3/assertions/theval"
+)
+
+func TestEqual(t *testing.T) {
+
+	t.Run("True", func(t *testing.T) {
+		// given
+		var errFunc assertiontesting.ErrFunc
+
+		// when
+		assert.Using(errFunc.Record).That(theval.Equal(0, 0))
+
+		// then
+		assert.
+			UsingFmt(t.Errorf).
+			That(errFunc.NotCalled())
+	})
+
+	t.Run("False", func(t *testing.T) {
+		// given
+		var errFunc assertiontesting.ErrFunc
+
+		// when
+		assert.Using(errFunc.Record).That(theval.Equal(0, 1))
+
+		// then
+		assert.
+			UsingFmt(t.Errorf).
+			That(errFunc.Called()).
+			That(errFunc.MessageFormatsTo("got 0, not 1"))
+	})
+
+}
+
+func TestNotEqual(t *testing.T) {
+
+	t.Run("True", func(t *testing.T) {
+		// given
+		var errFunc assertiontesting.ErrFunc
+
+		// when
+		assert.Using(errFunc.Record).That(theval.NotEqual(0, 1))
+
+		// then
+		assert.
+			UsingFmt(t.Errorf).
+			That(errFunc.NotCalled())
+	})
+
+	t.Run("False", func(t *testing.T) {
+		// given
+		var errFunc assertiontesting.ErrFunc
+
+		// when
+		assert.Using(errFunc.Record).That(theval.NotEqual(0, 0))
+
+		// then
+		assert.
+			UsingFmt(t.Errorf).
+			That(errFunc.Called()).
+			That(errFunc.MessageFormatsTo("got unwanted value 0"))
+	})
+
+}
+
+func TestLessThan(t *testing.T) {
+
+	t.Run("1vs3", func(t *testing.T) {
+		// given
+		var errFunc assertiontesting.ErrFunc
+
+		// when
+		assert.Using(errFunc.Record).That(theval.LessThan(1, 3))
+
+		// then
+		assert.
+			UsingFmt(t.Errorf).
+			That(errFunc.NotCalled())
+	})
+
+	t.Run("1vs1", func(t *testing.T) {
+		// given
+		var errFunc assertiontesting.ErrFunc
+
+		// when
+		assert.Using(errFunc.Record).That(theval.LessThan(1, 1))
+
+		// then
+		assert.
+			UsingFmt(t.Errorf).
+			That(errFunc.Called()).
+			That(errFunc.MessageFormatsTo("got 1 >= 1"))
+	})
+
+	t.Run("1vs0", func(t *testing.T) {
+		// given
+		var errFunc assertiontesting.ErrFunc
+
+		// when
+		assert.Using(errFunc.Record).That(theval.LessThan(1, 0))
+
+		// then
+		assert.
+			UsingFmt(t.Errorf).
+			That(errFunc.Called()).
+			That(errFunc.MessageFormatsTo("got 1 >= 0"))
+	})
+
+}
+
+func TestZero(t *testing.T) {
+
+	t.Run("True", func(t *testing.T) {
+		// given
+		var errFunc assertiontesting.ErrFunc
+
+		// when
+		assert.Using(errFunc.Record).That(theval.Zero(0))
+
+		// then
+		assert.UsingFmt(t.Errorf).That(errFunc.NotCalled())
+	})
+
+	t.Run("False", func(t *testing.T) {
+		// given
+		var errFunc assertiontesting.ErrFunc
+
+		// when
+		assert.Using(errFunc.Record).That(theval.Zero(1))
+
+		// then
+		assert.UsingFmt(t.Errorf).
+			That(errFunc.Called()).
+			That(errFunc.MessageFormatsTo("got 1, not zero value 0"))
+	})
+
+}
+
+func TestNotZero(t *testing.T) {
+
+	t.Run("True", func(t *testing.T) {
+		// given
+		var errFunc assertiontesting.ErrFunc
+
+		// when
+		assert.Using(errFunc.Record).That(theval.NotZero(1))
+
+		// then
+		assert.UsingFmt(t.Errorf).That(errFunc.NotCalled())
+	})
+
+	t.Run("False", func(t *testing.T) {
+		// given
+		var errFunc assertiontesting.ErrFunc
+
+		// when
+		assert.Using(errFunc.Record).That(theval.NotZero(0))
+
+		// then
+		assert.UsingFmt(t.Errorf).
+			That(errFunc.Called()).
+			That(errFunc.MessageFormatsTo("got zero value 0"))
+	})
+
+}

--- a/v3/doc.go
+++ b/v3/doc.go
@@ -21,34 +21,71 @@
 // SOFTWARE.
 
 /*
-Package assert provides a core, minimal API for making assertions.
+Package assert provides a flexible, extensible API for making assertions.
 
 To make a simple assertion that will panic on failure call:
 
-	assert.UsingPanic().That(false, "Oops")
+	assert.UsingPanic().True(false, "Oops")
 
 You can also format failure messages:
 
-	assert.UsingPanic().That(0 > 1, "%d is not greater than %d", 0, 1)
+	assert.UsingPanic().True(0 > 1, "%d is not greater than %d", 0, 1)
 
 UsingPanic returns an Asserter.
 You can chain multiple assertions on it.
 
 	assert.UsingPanic().
-	    That(1 > 0, "%d is not greater than %d", 1, 0).
-	    That(2 > 0, "%d is not greater than %d", 2, 0)
+	    True(1 > 0, "%d is not greater than %d", 1, 0).
+	    True(2 > 0, "%d is not greater than %d", 2, 0)
+
+# Reusable assertions
+
+True is good for ad hoc one-of assertions.
+
+We provide some pre-made reusable [assertions], so you can call
+
+	assert.UsingPanic().That(theval.Equal(got, want))
+
+instead of
+
+	assert.UsingPanic().True(got == want, "got %#v, not %#v", got, want)
+
+As long as the reusable assertion is well named, the first version is easier to read.
+It is also less error prone and easier to modify.
+
+# Custom assertions
+
+You can write your own reusable assertions as well.
+Just write a function that returns a non-nil error when the assertion fails:
+
+	func ErrIsNil(err error) error {
+	    if err != nil {
+			return fmt.Errorf("got unexpected non-nil error: %s", err)
+		}
+		retun nil
+	}
+
+You can then pass it's result to That:
+
+	assert.UsingPanic().That(ErrIsNil(err))
+
+You don't have to write the function in this example though.
+Just use [theerr.IsNil].
 
 # Alternative failure reactions
 
 Depending on the situation you might want different reactions to a failed assertion.
-To do that call Using with an ErrorFunc.
 
-	assert.Using(log.Panicf).That(0 > 1, "%d is not greater than %d", 0, 1)
+The common case for that is to call a function that at least outputs some information.
+To do that call UsingFmt.
 
-An ErrorFunc specifies what the reaction to failure should be.
-When Using is passed a nil ErrorFunc, it behaves the same as UsingPanic.
+	assert.UsingFmt(log.Panicf).That(0 > 1, "%d is not greater than %d", 0, 1)
 
-You can use many functions and methods in the standard library as ErrorFuncs.
+The argument to UsingFmt has a the signature
+
+	func(string, ...any)
+
+Many functions and methods in the standard library have that signature.
 For example:
 
   - testing.(*T).Errorf
@@ -57,55 +94,11 @@ For example:
   - log.Panicf
   - log.Fatalf
 
-# Reusable assertions
+UsingFmt will pass messages of any non-nil errors to the function.
 
-We provide some pre-made reusable [assertions], so you can call
+# If for some reason you need the error itself, call Using instead.
 
-	assert.UsingPanic().That(theval.Equal(got, want))
-
-instead of
-
-	assert.UsingPanic().That(got == want, "got %#v, not %#v", got, want)
-
-As long as the reusable assertion is well named, the first version is easier to read.
-The first version is also less error prone and easier to modify.
-In more complex cases a reusable assertion can also provide more detailed error messages.
-
-Reusable assertions rely on a feature of Go that is used relatively rarely.
-You can read about it in the [Calls] section of the Go language specification.
-
-# Custom assertions
-
-You can write your own reusable assertions as well.
-Just write a function that returns the arguments you would pass to That:
-
-	func ErrIsNil(err error) (bool, string) {
-	    return err == nil, fmt.Sprintf("unexpected error: %s", err)
-	}
-
-You can then pass it's result to That instead of writing the arguments out:
-
-	assert.UsingPanic().That(ErrIsNil(err))
-
-We could have written ErrIsNil this way as well:
-
-	func ErrIsNil(err error) (bool, string, any) {
-	    return err == nil, "unexpected error: %s, any
-	}
-
-We recommend that custom assertions return (bool, string).
-All the reusable assertions we provide are written this way.
-This
-
-  - makes them easier to recognize,
-  - makes them easier to modify, and
-  - allows us to provide better error messages for complex cases.
-
-You don't have to write the function in this example though.
-Just use [theerr.IsNil].
-
-[assertions]: https://pkg.go.dev/github.com/szabba/assert/v2/assertions
-[Calls]: https://go.dev/ref/spec#Calls
-[theerr.IsNil]: https://pkg.go.dev/github.com/szabba/assert/v2/assertions/theerr#IsNil
+[assertions]: https://pkg.go.dev/github.com/szabba/assert/v3/assertions
+[theerr.IsNil]: https://pkg.go.dev/github.com/szabba/assert/v3/assertions/theerr#IsNil
 */
 package assert

--- a/v3/doc.go
+++ b/v3/doc.go
@@ -96,7 +96,8 @@ For example:
 
 UsingFmt will pass messages of any non-nil errors to the function.
 
-# If for some reason you need the error itself, call Using instead.
+Sometimes you might need the error itself - not just the message.
+In that case you want to call Using, not UsingPanic or UsingFmt.
 
 [assertions]: https://pkg.go.dev/github.com/szabba/assert/v3/assertions
 [theerr.IsNil]: https://pkg.go.dev/github.com/szabba/assert/v3/assertions/theerr#IsNil

--- a/v3/doc.go
+++ b/v3/doc.go
@@ -1,0 +1,111 @@
+// MIT License
+//
+// Copyright (c) 2022 Karol Marcjan
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+/*
+Package assert provides a core, minimal API for making assertions.
+
+To make a simple assertion that will panic on failure call:
+
+	assert.UsingPanic().That(false, "Oops")
+
+You can also format failure messages:
+
+	assert.UsingPanic().That(0 > 1, "%d is not greater than %d", 0, 1)
+
+UsingPanic returns an Asserter.
+You can chain multiple assertions on it.
+
+	assert.UsingPanic().
+	    That(1 > 0, "%d is not greater than %d", 1, 0).
+	    That(2 > 0, "%d is not greater than %d", 2, 0)
+
+# Alternative failure reactions
+
+Depending on the situation you might want different reactions to a failed assertion.
+To do that call Using with an ErrorFunc.
+
+	assert.Using(log.Panicf).That(0 > 1, "%d is not greater than %d", 0, 1)
+
+An ErrorFunc specifies what the reaction to failure should be.
+When Using is passed a nil ErrorFunc, it behaves the same as UsingPanic.
+
+You can use many functions and methods in the standard library as ErrorFuncs.
+For example:
+
+  - testing.(*T).Errorf
+  - testing.(*T).Fatalf
+  - log.Printf
+  - log.Panicf
+  - log.Fatalf
+
+# Reusable assertions
+
+We provide some pre-made reusable [assertions], so you can call
+
+	assert.UsingPanic().That(theval.Equal(got, want))
+
+instead of
+
+	assert.UsingPanic().That(got == want, "got %#v, not %#v", got, want)
+
+As long as the reusable assertion is well named, the first version is easier to read.
+The first version is also less error prone and easier to modify.
+In more complex cases a reusable assertion can also provide more detailed error messages.
+
+Reusable assertions rely on a feature of Go that is used relatively rarely.
+You can read about it in the [Calls] section of the Go language specification.
+
+# Custom assertions
+
+You can write your own reusable assertions as well.
+Just write a function that returns the arguments you would pass to That:
+
+	func ErrIsNil(err error) (bool, string) {
+	    return err == nil, fmt.Sprintf("unexpected error: %s", err)
+	}
+
+You can then pass it's result to That instead of writing the arguments out:
+
+	assert.UsingPanic().That(ErrIsNil(err))
+
+We could have written ErrIsNil this way as well:
+
+	func ErrIsNil(err error) (bool, string, any) {
+	    return err == nil, "unexpected error: %s, any
+	}
+
+We recommend that custom assertions return (bool, string).
+All the reusable assertions we provide are written this way.
+This
+
+  - makes them easier to recognize,
+  - makes them easier to modify, and
+  - allows us to provide better error messages for complex cases.
+
+You don't have to write the function in this example though.
+Just use [theerr.IsNil].
+
+[assertions]: https://pkg.go.dev/github.com/szabba/assert/v2/assertions
+[Calls]: https://go.dev/ref/spec#Calls
+[theerr.IsNil]: https://pkg.go.dev/github.com/szabba/assert/v2/assertions/theerr#IsNil
+*/
+package assert

--- a/v3/example_test.go
+++ b/v3/example_test.go
@@ -1,0 +1,46 @@
+// MIT License
+//
+// Copyright (c) 2018 Karol Marcjan
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package assert_test
+
+import (
+	"io"
+	"log"
+	"os"
+
+	"github.com/szabba/assert/v3"
+	"github.com/szabba/assert/v3/assertions/theerr"
+)
+
+func Example() {
+	defer log.SetFlags(log.Flags())
+	defer log.SetOutput(os.Stderr)
+
+	log.SetFlags(0)
+	log.SetOutput(os.Stdout)
+
+	assert.UsingFmt(log.Printf).
+		That(theerr.IsNil(io.EOF))
+
+	// Output:
+	// unexpected error: EOF
+}

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -1,0 +1,5 @@
+module github.com/szabba/assert/v3
+
+go 1.20
+
+require golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1

--- a/v3/go.sum
+++ b/v3/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
+golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=


### PR DESCRIPTION
* Redesigned with assertions returning `error`.
    * No longer relies on a relatively obscure bit of the Go language spec.
    * Most assertions are written in a more natural (for Go) style.
 
* `Asserter`s now have two assertion methods:
    * `Asserter.That` for the reusable assertions.
    * `Asserter.True` for ad-hoc assertions.

* Package docs reorganized. Hopefully less confusing.

* The family of `Using*` functions grows.
    * `UsingPanic` acts like before.
    * `UsingFmt` has the old signature of `Using` and behaves like it.
    * `Using` now accepts a `func(error)`, in case the caller cares about the error value, not just the message.
    * The docs explicitly mention that `UsingFmt` is preferred in tests.

TODO:
* [ ] Implement v2 in terms of v3.
* [ ] Implement v1 in terms of v3.